### PR TITLE
2 functionality

### DIFF
--- a/gitHub.js
+++ b/gitHub.js
@@ -1,13 +1,16 @@
+const readline = require('readline');
 const dayjs = require("dayjs");
 require('dotenv').config();
 
 const today = dayjs().format("YYYY-MM-DD");
 const weekAgo = dayjs().subtract(8, 'days').format("YYYY-MM-DD");
 
-async function getCommitsSince(user) {
-    const isUserReal = await verifyUser(user);
-    console.log(user, isUserReal);
-    if (!isUserReal) return ['User does not exist.'];
+async function getCommitsSince(user, currentUser, totalUsers) {
+    readline.cursorTo(process.stdout, 0);
+    readline.clearLine(process.stdout, 0);
+    process.stdout.write(`Processing ${currentUser + 1}/${totalUsers} users...`);
+
+    if (!await verifyUser(user)) return ['User does not exist.'];
     
     return ['User exists.'];
 }
@@ -25,9 +28,6 @@ async function verifyUser(user) {
 
     if (res.ok) {
         const data = await res.json();
-
-        console.log(user, data["total_count"]);
-
         return (data["total_count"] >= 1) ? true : false;
     }
 

--- a/gitHub.js
+++ b/gitHub.js
@@ -4,11 +4,38 @@ require('dotenv').config();
 const today = dayjs().format("YYYY-MM-DD");
 const weekAgo = dayjs().subtract(8, 'days').format("YYYY-MM-DD");
 
-async function getCommitsSince(user, timeFrame) {
-    let url;
-    if (timeFrame === "one-week-ago") {
-        url = `https://api.github.com/search/commits?q=author:${user}+committer-date:${weekAgo}..${today}`;
+async function getCommitsSince(user) {
+    const isUserReal = await verifyUser(user);
+    console.log(user, isUserReal);
+    if (!isUserReal) return ['User does not exist.'];
+    
+    return ['User exists.'];
+}
+
+async function verifyUser(user) {
+    if (!user) return false;
+
+    const res = await fetch(`https://api.github.com/search/users?q=${user}`, {
+        headers: {
+            'Authorization': `Bearer ${process.env.gitHubToken}`,
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28'
+        }
+    });
+
+    if (res.ok) {
+        const data = await res.json();
+
+        console.log(user, data["total_count"]);
+
+        return (data["total_count"] >= 1) ? true : false;
     }
+
+    return false;
+}
+
+async function getWeekAgo() {
+    const url = `https://api.github.com/search/commits?q=author:${user}+committer-date:${weekAgo}..${today}`;
 
     const res = await fetch(url, {
         headers: {
@@ -20,7 +47,7 @@ async function getCommitsSince(user, timeFrame) {
 
     if (res.ok) {
         const data = await res.json();
-        
+
         if (res.headers.get("x-ratelimit-remaining") === "0") {
             const secondsToWait = (+res.headers.get("x-ratelimit-reset") - dayjs().unix()) + 1;
             await new Promise(resolve => setTimeout(resolve, secondsToWait * 1000));
@@ -32,6 +59,14 @@ async function getCommitsSince(user, timeFrame) {
         console.log(data.message);
         process.exit(1);
     }
+}
+
+async function getMonthAgo() {
+
+}
+
+async function wait() {
+
 }
 
 module.exports.getCommitsSince = getCommitsSince;

--- a/googleSheets.js
+++ b/googleSheets.js
@@ -11,7 +11,7 @@ const service = sheets({ version: "v4", auth });
 async function getUsers() {
     const readData = await service.spreadsheets.values.get({
         spreadsheetId: process.env.spreadsheetId,
-        range: "GitHub!C2:C",
+        range: "GitHub-2!C2:C",
     })
 
     return readData.data.values;
@@ -20,7 +20,7 @@ async function getUsers() {
 async function updateCommits(commits) {
     await service.spreadsheets.values.update({
         spreadsheetId: process.env.spreadsheetId,
-        range: "GitHub!D2:D",
+        range: "GitHub-2!D2:D",
         valueInputOption: "USER_ENTERED",
         resource: {
             values: commits

--- a/googleSheets.js
+++ b/googleSheets.js
@@ -11,7 +11,7 @@ const service = sheets({ version: "v4", auth });
 async function getUsers() {
     const readData = await service.spreadsheets.values.get({
         spreadsheetId: process.env.spreadsheetId,
-        range: "GitHub-2!C2:C",
+        range: "GitHub!C2:C",
     })
 
     return readData.data.values;
@@ -20,7 +20,7 @@ async function getUsers() {
 async function updateCommits(commits) {
     await service.spreadsheets.values.update({
         spreadsheetId: process.env.spreadsheetId,
-        range: "GitHub-2!D2:D",
+        range: "GitHub!D2:E",
         valueInputOption: "USER_ENTERED",
         resource: {
             values: commits

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ async function fillSheet() {
 
     const commits = [];
     for (let user of users) {
-        commits.push(await gitHub.getCommitsSince(user[0], "one-week-ago"));
+        commits.push(await gitHub.getCommitsSince(user[0]));
     }
 
     await googleSheets.updateCommits(commits);

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ async function fillSheet() {
     const users = await googleSheets.getUsers();
 
     const commits = [];
-    for (let user of users) {
-        commits.push(await gitHub.getCommitsSince(user[0]));
+    for (let i = 0; i < users.length; i++) {
+        commits.push(await gitHub.getCommitsSince(users[i][0], i, users.length));
     }
 
     await googleSheets.updateCommits(commits);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "dayjs": "^1.11.9",
         "dotenv": "^16.3.1",
         "google-auth-library": "^9.0.0"
+      },
+      "engines": {
+        "node": "18.x.x"
       }
     },
     "node_modules/@googleapis/sheets": {


### PR DESCRIPTION
References #2.

- Every user is now verified through `/search/users` before getting their commits. I tried using `users` but it has a rate limit of 60 per hour.
- Get average commits from previous four weeks.
- For every GitHub API request, now first checks response status code to see if rate limit reached, then waits.
- One-line console output showing 'Processing <current-index>/<total-users>...' which switches to 'Waiting for <seconds> seconds...' when waiting for rate limit to refill. This helped me know what was happening throughout the very long local runs.

**How To Test**
Make sure you have the spreadsheet ID, GitHub access token and the GCP key in your .env file then run `node cli.js` at the root of the project.