### PR TITLE
Allow case-insensitive matching of GitHub logins

### DIFF
--- a/e2e.test.js
+++ b/e2e.test.js
@@ -52,6 +52,30 @@ describe("GitHub Tracker", () => {
 		});
 	});
 
+	it("works with inconsistent casing", async () => {
+		const title = await createSheet([
+			["GitHub ID", "Commits last week"],
+			["tExTbOoK"],
+			["Haroon-Ali-DEV"],
+			["MOMAHBOOBIAN"],
+			["lorenacapraru"],
+		]);
+
+		await runScript({ END_DATE: "2023-06-18", WORKSHEET_NAME: title });
+
+		const { data: { values } } = await sheetsClient.spreadsheets.values.get({
+			range: `${title}!A2:B`,
+			spreadsheetId,
+		});
+		const commitCounts = Object.fromEntries(values);
+		assert.deepEqual(commitCounts, {
+			"Haroon-Ali-DEV": "96",
+			lorenacapraru: "2",
+			MOMAHBOOBIAN: "3",
+			tExTbOoK: "1",
+		});
+	});
+
 	/**
 	 * @param {string[][]} values
 	 * @returns {Promise<string>}

--- a/github.js
+++ b/github.js
@@ -44,9 +44,10 @@ export class GitHub {
 	 * @returns {Promise<boolean>}
 	 */
 	async validUsername(username) {
+		const canonical = username.toLowerCase();
 		try {
-			const { data: { items } } = await this.service.search.users({ q: `user:${username}` });
-			return items.find(({ login }) => login === username) !== undefined;
+			const { data: { items } } = await this.service.search.users({ q: `user:${canonical}` });
+			return items.find(({ login }) => login.toLowerCase() === canonical) !== undefined;
 		} catch (/** @type {any} */err) {
 			if (err.status === 422) {
 				return false;

--- a/github.spec.js
+++ b/github.spec.js
@@ -24,7 +24,7 @@ describe("GitHub", () => {
 				rest.get("https://api.github.com/search/commits", (req, res, ctx) => {
 					headers = Object.fromEntries(req.headers.entries());
 					query = Object.fromEntries(req.url.searchParams.entries());
-					return res(ctx.json({ total_count: 0, incomplete_results: false, items: [] }));
+					return res(ctx.json(envelope([])));
 				}),
 			);
 
@@ -41,7 +41,7 @@ describe("GitHub", () => {
 				}),
 			);
 
-			assert.equal(await github.commitsBetween("textbook", new Date(2023, 4, 5, 12), new Date(2023, 4, 12, 12)), 123);
+			assert.equal(await github.commitsBetween("textbook", new Date(), new Date()), 123);
 		});
 	});
 
@@ -52,7 +52,7 @@ describe("GitHub", () => {
 				rest.get("https://api.github.com/search/users", (req, res, ctx) => {
 					headers = Object.fromEntries(req.headers.entries());
 					query = Object.fromEntries(req.url.searchParams.entries());
-					return res(ctx.json({ total_count: 0, incomplete_results: false, items: [] }));
+					return res(ctx.json(envelope([])));
 				}),
 			);
 
@@ -65,13 +65,9 @@ describe("GitHub", () => {
 		it("resolves true if username is found in search", async () => {
 			server.use(
 				rest.get("https://api.github.com/search/users", (req, res, ctx) => {
-					return res(ctx.json({
-						total_count: 1,
-						incomplete_results: false,
-						items: [
-							{ id: 123, login: "textbook" },
-						],
-					}));
+					return res(ctx.json(envelope([
+						{ id: 123, login: "textbook" },
+					])));
 				}),
 			);
 
@@ -81,15 +77,11 @@ describe("GitHub", () => {
 		it("resolves false if username is not found in search", async () => {
 			server.use(
 				rest.get("https://api.github.com/search/users", (req, res, ctx) => {
-					return res(ctx.json({
-						total_count: 1,
-						incomplete_results: false,
-						items: [
-							{ id: 123, login: "foo" },
-							{ id: 456, login: "bar" },
-							{ id: 789, login: "baz" },
-						],
-					}));
+					return res(ctx.json(envelope([
+						{ id: 123, login: "foo" },
+						{ id: 456, login: "bar" },
+						{ id: 789, login: "baz" },
+					])));
 				}),
 			);
 
@@ -118,7 +110,7 @@ describe("GitHub", () => {
 		it("retries if rate limit is hit", async () => {
 			const responses = [
 				{ json: { message: "API rate limit exceeded for user ID 123456" }, remaining: 0, status: 403 },
-				{ json: { incomplete_results: false, items: [{ id: 123, login: "textbook" }], total_count: 0 }, remaining: 100, status: 200 },
+				{ json: envelope([{ id: 123, login: "textbook" }]), remaining: 100, status: 200 },
 			];
 			server.use(
 				rest.get("https://api.github.com/search/users", (req, res, ctx) => {
@@ -155,4 +147,12 @@ describe("GitHub", () => {
 			assert.equal(count, 3);
 		});
 	});
+
+	function envelope(items) {
+		return {
+			items,
+			total_count: items.length,
+			incomplete_results: false,
+		};
+	}
 });

--- a/github.spec.js
+++ b/github.spec.js
@@ -88,6 +88,14 @@ describe("GitHub", () => {
 			assert.equal(await github.validUsername("textbook"), false);
 		});
 
+		it("accepts case-insensitive matches", async () => {
+			server.use(rest.get("https://api.github.com/search/users", (req, res, ctx) => res(ctx.json(envelope([
+				{ id: 123, login: "tExTbOOk" },
+			])))));
+
+			assert.equal(await github.validUsername("textbook"), true);
+		});
+
 		it("resolves false if search responds 422", async () => {
 			server.use(
 				rest.get("https://api.github.com/search/users", (req, res, ctx) => {


### PR DESCRIPTION
This is a:

<!-- Tick one category - if more than one applies, it should be split up -->

- [ ] ✨ **New feature** - new behaviour has been implemented
- [x] 🐛 **Bug fix** - existing behaviour has been made to behave
- [ ] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ✅ **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
- [ ] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

<!-- adapted from https://gitmoji.dev/ -->

### Description

<!-- Describe what merging this pull request will do -->

- **Purpose** - allow case-insensitive matchers for graduates' GitHub logins

<!-- Describe how the reviewer should check it works -->

- **How to check** - previously, using a slightly different casing to what's shown on the user's profile page (e.g. `"Textbook"` instead of `"textbook"`) would have caused `GitHub#validUsername` to return `false`, even though that user would be successfully found in the commits search, so their commit count is shown as `#N/A`. With this fix, their commit count should show up as an actual number.

### Links

<!-- links to other issues/PRs/tickets, e.g. user/repo#123 -->
- N/A
