### PR TITLE
Set explicit names for cron jobs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -26,6 +26,7 @@ jobs:
           - commitRange: "M3:M"
             userRange: "L3:L"
             worksheetName: "West Midlands"
+    name: "Weekly update: ${{ matrix.worksheetName }}"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-node@v3"


### PR DESCRIPTION
This is a:

<!-- Tick one category - if more than one applies, it should be split up -->

- [ ] ✨ **New feature** - new behaviour has been implemented
- [ ] 🐛 **Bug fix** - existing behaviour has been made to behave
- [ ] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ✅ **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
- [x] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

<!-- adapted from https://gitmoji.dev/ -->

### Description

<!-- Describe what merging this pull request will do -->

- **Purpose** - rather than the automatically-generated job names, e.g. _"run (M3:M, L3:L, West Midlands)"_, set an explicit name _"Weekly update: West Midlands"_. This will show up in the GitHub web UI and the deployment notifications send to the team Slack channel.

- **How to check** - although our [deployment protection rules](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules) mean the jobs can't actually run (the credentials for the production environment are only exposed to workflows on the main branch), you can see the appropriate _names_ used in the web UI [here](https://github.com/CodeYourFuture/github-tracker/actions/runs/5991379350) and on Slack [here](https://codeyourfuture.slack.com/archives/C05KRSUPX4G/p1693145058808129).

### Links

- N/A
